### PR TITLE
Fix risk acceptance approval flow

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -1495,7 +1495,7 @@ class RiskAcceptanceSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         instance = super().create(validated_data)
         user = getattr(self.context.get("request", None), "user", None)
-        ra_helper.add_findings_to_risk_acceptance(user, instance, instance.accepted_findings.all())
+        ra_helper.add_findings_to_risk_acceptance(user, instance, instance.accepted_findings.all(), apply=instance.approved)
         return instance
 
     def update(self, instance, validated_data):
@@ -1511,7 +1511,7 @@ class RiskAcceptanceSerializer(serializers.ModelSerializer):
         instance = super().update(instance, validated_data)
         user = getattr(self.context.get("request", None), "user", None)
         # Add the new findings
-        ra_helper.add_findings_to_risk_acceptance(user, instance, findings_to_add)
+        ra_helper.add_findings_to_risk_acceptance(user, instance, findings_to_add, apply=instance.approved)
         # Remove the ones that were not present in the payload
         for finding in findings_to_remove:
             ra_helper.remove_finding_from_risk_acceptance(user, instance, finding)

--- a/dojo/db_migrations/0236_risk_acceptance_approval.py
+++ b/dojo/db_migrations/0236_risk_acceptance_approval.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+
+
+def approve_existing_risk_acceptances(apps, schema_editor):
+    RiskAcceptance = apps.get_model('dojo', 'Risk_Acceptance')
+    RiskAcceptance.objects.update(approved=True)
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('dojo', '0235_clean_tags'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='risk_acceptance',
+            name='approved',
+            field=models.BooleanField(
+                default=False,
+                help_text='Whether this risk acceptance has been approved by the owner.',
+            ),
+        ),
+        migrations.RunPython(approve_existing_risk_acceptances, migrations.RunPython.noop),
+    ]

--- a/dojo/engagement/urls.py
+++ b/dojo/engagement/urls.py
@@ -44,6 +44,8 @@ urlpatterns = [
         views.expire_risk_acceptance, name="expire_risk_acceptance"),
     re_path(r"^engagement/(?P<eid>\d+)/risk_acceptance/(?P<raid>\d+)/reinstate$",
         views.reinstate_risk_acceptance, name="reinstate_risk_acceptance"),
+    re_path(r"^engagement/(?P<eid>\d+)/risk_acceptance/(?P<raid>\d+)/approve$",
+        views.approve_risk_acceptance, name="approve_risk_acceptance"),
     re_path(r"^engagement/(?P<eid>\d+)/risk_acceptance/(?P<raid>\d+)/delete$",
         views.delete_risk_acceptance, name="delete_risk_acceptance"),
     re_path(r"^engagement/(?P<eid>\d+)/risk_acceptance/(?P<raid>\d+)/download$",
@@ -56,4 +58,6 @@ urlpatterns = [
         views.csv_export, name="engagement_csv_export"),
     re_path(r"^engagement/excel_export$",
         views.excel_export, name="engagement_excel_export"),
+    re_path(r"^risk_acceptance/requests$",
+        views.pending_risk_acceptances, name="pending_risk_acceptances"),
 ]

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -838,6 +838,7 @@ class EditRiskAcceptanceForm(forms.ModelForm):
 
     path = forms.FileField(label="Proof", required=False, widget=forms.widgets.FileInput(attrs={"accept": ".jpg,.png,.pdf"}))
     expiration_date = forms.DateTimeField(required=False, widget=forms.TextInput(attrs={"class": "datepicker"}))
+    approved = forms.BooleanField(required=False, label="Approved")
 
     class Meta:
         model = Risk_Acceptance
@@ -860,6 +861,7 @@ class RiskAcceptanceForm(EditRiskAcceptanceForm):
     notes = forms.CharField(required=False, max_length=2400,
                             widget=forms.Textarea,
                             label="Notes")
+    approved = forms.BooleanField(required=False, widget=forms.HiddenInput(), initial=False)
 
     class Meta:
         model = Risk_Acceptance
@@ -932,6 +934,12 @@ class AddFindingsRiskAcceptanceForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["accepted_findings"].queryset = get_authorized_findings(Permissions.Risk_Acceptance)
+
+
+class ApproveRiskAcceptanceForm(forms.ModelForm):
+    class Meta:
+        model = Risk_Acceptance
+        fields = ["recommendation", "recommendation_details", "expiration_date"]
 
 
 class CheckForm(forms.ModelForm):

--- a/dojo/jira_link/helper.py
+++ b/dojo/jira_link/helper.py
@@ -1782,7 +1782,7 @@ def process_resolution_from_jira(finding, resolution_id, resolution_name, assign
                         decision_details=f"Risk Acceptance automatically created from JIRA issue {jira_issue.jira_key} with resolution {resolution_name}",
                     )
                     finding.test.engagement.risk_acceptance.add(ra)
-                    ra_helper.add_findings_to_risk_acceptance(User.objects.get_or_create(username="JIRA")[0], ra, [finding])
+                    ra_helper.add_findings_to_risk_acceptance(User.objects.get_or_create(username="JIRA")[0], ra, [finding], apply=ra.approved)
                 status_changed = True
         elif jira_instance and resolution_name in jira_instance.false_positive_resolutions:
             if not finding.false_p:

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -3715,6 +3715,8 @@ class Risk_Acceptance(models.Model):
                             blank=True, verbose_name=_("Proof"))
     owner = models.ForeignKey(Dojo_User, editable=True, on_delete=models.RESTRICT, help_text=_("User in DefectDojo owning this acceptance. Only the owner and staff users can edit the risk acceptance."))
 
+    approved = models.BooleanField(default=False, help_text=_("Whether this risk acceptance has been approved by the owner."))
+
     expiration_date = models.DateTimeField(default=None, null=True, blank=True, help_text=_("When the risk acceptance expires, the findings will be reactivated (unless disabled below)."))
     expiration_date_warned = models.DateTimeField(default=None, null=True, blank=True, help_text=_("(readonly) Date at which notice about the risk acceptance expiration was sent."))
     expiration_date_handled = models.DateTimeField(default=None, null=True, blank=True, help_text=_("(readonly) When the risk acceptance expiration was handled (manually or by the daily job)."))

--- a/dojo/risk_acceptance/helper.py
+++ b/dojo/risk_acceptance/helper.py
@@ -124,14 +124,21 @@ def remove_finding_from_risk_acceptance(user: Dojo_User, risk_acceptance: Risk_A
     return
 
 
-def add_findings_to_risk_acceptance(user: Dojo_User, risk_acceptance: Risk_Acceptance, findings: list[Finding]) -> None:
+def add_findings_to_risk_acceptance(
+    user: Dojo_User,
+    risk_acceptance: Risk_Acceptance,
+    findings: list[Finding],
+    *,
+    apply: bool = True,
+) -> None:
     for finding in findings:
         if not finding.duplicate or finding.risk_accepted:
-            finding.active = False
-            finding.risk_accepted = True
-            finding.save(dedupe_option=False)
-            # Update any endpoint statuses on each of the findings
-            update_endpoint_statuses(finding, accept_risk=True)
+            if apply:
+                finding.active = False
+                finding.risk_accepted = True
+                finding.save(dedupe_option=False)
+                # Update any endpoint statuses on each of the findings
+                update_endpoint_statuses(finding, accept_risk=True)
             risk_acceptance.accepted_findings.add(finding)
         # Add a note to reflect that the finding was removed from the risk acceptance
         if user is not None:

--- a/dojo/templates/base.html
+++ b/dojo/templates/base.html
@@ -328,6 +328,11 @@
                                                         {% trans "Risk Accepted Findings" %}
                                                     </a>
                                                 </li>
+                                                <li>
+                                                    <a href="{% url 'pending_risk_acceptances' %}">
+                                                        {% trans "Risk Acceptance Requests" %}
+                                                    </a>
+                                                </li>
                                                 {% if "Finding_View"|has_global_permission %}
                                                     <li>
                                                         <a href="{% url 'templates' %}">

--- a/dojo/templates/dojo/approve_risk_acceptance.html
+++ b/dojo/templates/dojo/approve_risk_acceptance.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% load display_tags %}
+{% block content %}
+<h3>Approve Risk Acceptance</h3>
+<form method="post" enctype="multipart/form-data">
+  {% csrf_token %}
+  {% include 'dojo/form_fields.html' with form=form %}
+  <input type="submit" class="btn btn-primary" value="Approve"/>
+</form>
+{% endblock %}

--- a/dojo/templates/dojo/pending_risk_acceptances.html
+++ b/dojo/templates/dojo/pending_risk_acceptances.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+{% load display_tags %}
+{% block content %}
+<h3>Pending Risk Acceptances</h3>
+<table class="table table-striped">
+  <thead>
+    <tr><th>Name</th><th>Engagement</th><th>Submitted</th><th></th></tr>
+  </thead>
+  <tbody>
+    {% for ra in risk_acceptances %}
+    <tr>
+      <td>{{ ra.name }}</td>
+      <td><a href="{% url 'view_engagement' ra.engagement.id %}">{{ ra.engagement }}</a></td>
+      <td>{{ ra.created|date }}</td>
+      <td><a class="btn btn-sm btn-success" href="{% url 'approve_risk_acceptance' ra.engagement.id ra.id %}">Approve</a></td>
+    </tr>
+    {% empty %}
+    <tr><td colspan="4">No pending requests.</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/dojo/templates/dojo/snippets/risk_acceptance_actions_snippet.html
+++ b/dojo/templates/dojo/snippets/risk_acceptance_actions_snippet.html
@@ -8,6 +8,13 @@
         </a>
     </li>
 {% endif %}
+{% if not risk_acceptance.approved and risk_acceptance.owner == request.user %}
+    <li role="presentation">
+        <a href="{% url 'approve_risk_acceptance' engagement.id risk_acceptance.id %}?return_url={{ request.get_full_path|urlencode }}">
+            <i class="fa-solid fa-check"></i> Approve
+        </a>
+    </li>
+{% endif %}
 
 {% if engagement.product.enable_full_risk_acceptance %}
     {% if engagement|has_object_permission:"Risk_Acceptance" %}

--- a/dojo/templates/dojo/view_eng.html
+++ b/dojo/templates/dojo/view_eng.html
@@ -400,6 +400,7 @@
                                             <th>Findings</th>
                                             <th>Proof</th>
                                             <th>Owner</th>
+                                            <th>Status</th>
                                             {% endblock risk_acceptance_header %}
                                         </tr>
                                     </thead>
@@ -447,6 +448,7 @@
                                                     <td>No</a></td>
                                                 {% endif %}
                                                 <td>{{ risk_acceptance.owner.get_full_name }}</td>
+                                                <td>{% if risk_acceptance.approved %}Approved{% else %}Pending{% endif %}</td>
                                                 {% endblock risk_acceptances %}
                                             </tr>
                                         {% endfor %}

--- a/dojo/templates/dojo/view_risk_acceptance.html
+++ b/dojo/templates/dojo/view_risk_acceptance.html
@@ -68,6 +68,9 @@
                         </ul>
                     </div>
                 </div>
+                {% if not risk_acceptance.approved %}
+                    <div class="alert alert-warning">Pending approval</div>
+                {% endif %}
             </div>
             <div class="table-responsive">
                 <table class="table-striped table table-condensed table-hover centered">


### PR DESCRIPTION
## Summary
- update migration to set existing risk acceptances as approved
- add a form and view for approving a risk acceptance with security recommendations
- expose approval page through templates

## Testing
- `ruff check .`
- `python manage.py makemigrations --check` *(fails: ModuleNotFoundError: No module named 'split_settings')*
- `python manage.py test dojo.tests.test_risk_acceptance_models -v 2` *(fails: ModuleNotFoundError: No module named 'split_settings')*

------
https://chatgpt.com/codex/tasks/task_e_6882b60eed7c8329a0aa572acb12dcd6