### PR TITLE
Improve risk acceptance approval workflow

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -2838,6 +2838,9 @@ class NotificationsSerializer(serializers.ModelSerializer):
     risk_acceptance_expiration = MultipleChoiceField(
         choices=NOTIFICATION_CHOICES, default=DEFAULT_NOTIFICATION,
     )
+    risk_acceptance_request = MultipleChoiceField(
+        choices=NOTIFICATION_CHOICES, default=DEFAULT_NOTIFICATION,
+    )
     template = serializers.BooleanField(default=False)
 
     class Meta:

--- a/dojo/db_migrations/0237_alter_risk_acceptance_approved.py
+++ b/dojo/db_migrations/0237_alter_risk_acceptance_approved.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("dojo", "0236_risk_acceptance_approval"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="risk_acceptance",
+            name="approved",
+            field=models.BooleanField(
+                default=False,
+                help_text="Whether this risk acceptance has been approved by the owner.",
+            ),
+        ),
+    ]

--- a/dojo/db_migrations/0238_risk_acceptance_permanent_and_notifications.py
+++ b/dojo/db_migrations/0238_risk_acceptance_permanent_and_notifications.py
@@ -1,0 +1,35 @@
+# ruff: noqa: N999
+import multiselectfield.db.fields
+from django.contrib.auth.models import Group
+from django.db import migrations, models
+
+
+def create_risk_approvers(apps, schema_editor):
+    Group.objects.get_or_create(name="Risk-Approvers")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("dojo", "0237_alter_risk_acceptance_approved"),
+        ("auth", "0012_alter_user_first_name_max_length"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="risk_acceptance",
+            name="permanent",
+            field=models.BooleanField(default=False, help_text="Indicates this risk acceptance does not expire."),
+        ),
+        migrations.AddField(
+            model_name="notifications",
+            name="risk_acceptance_request",
+            field=multiselectfield.db.fields.MultiSelectField(
+                blank=True,
+                choices=[("slack", "slack"), ("msteams", "msteams"), ("mail", "mail"), ("alert", "alert")],
+                default=("alert", "alert"),
+                max_length=24,
+                verbose_name="Risk Acceptance Requests",
+            ),
+        ),
+        migrations.RunPython(create_risk_approvers, migrations.RunPython.noop),
+    ]

--- a/dojo/forms.py
+++ b/dojo/forms.py
@@ -839,6 +839,7 @@ class EditRiskAcceptanceForm(forms.ModelForm):
     path = forms.FileField(label="Proof", required=False, widget=forms.widgets.FileInput(attrs={"accept": ".jpg,.png,.pdf"}))
     expiration_date = forms.DateTimeField(required=False, widget=forms.TextInput(attrs={"class": "datepicker"}))
     approved = forms.BooleanField(required=False, label="Approved")
+    permanent = forms.BooleanField(required=False, label="Permanent")
 
     class Meta:
         model = Risk_Acceptance
@@ -862,6 +863,7 @@ class RiskAcceptanceForm(EditRiskAcceptanceForm):
                             widget=forms.Textarea,
                             label="Notes")
     approved = forms.BooleanField(required=False, widget=forms.HiddenInput(), initial=False)
+    permanent = forms.BooleanField(required=False, label="Permanent")
 
     class Meta:
         model = Risk_Acceptance
@@ -934,6 +936,16 @@ class AddFindingsRiskAcceptanceForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields["accepted_findings"].queryset = get_authorized_findings(Permissions.Risk_Acceptance)
+
+
+class ApproveRiskAcceptanceForm(forms.ModelForm):
+    decision = forms.ChoiceField(choices=Risk_Acceptance.TREATMENT_CHOICES, widget=forms.RadioSelect)
+    decision_details = forms.CharField(required=False, widget=forms.Textarea, label="Decision Details")
+    permanent = forms.BooleanField(required=False, label="Permanent")
+
+    class Meta:
+        model = Risk_Acceptance
+        fields = ["decision", "decision_details", "permanent"]
 
 
 class CheckForm(forms.ModelForm):
@@ -2930,10 +2942,11 @@ class ProductNotificationsForm(forms.ModelForm):
             self.initial["sla_breach"] = ""
             self.initial["sla_breach_combined"] = ""
             self.initial["risk_acceptance_expiration"] = ""
+            self.initial["risk_acceptance_request"] = ""
 
     class Meta:
         model = Notifications
-        fields = ["engagement_added", "close_engagement", "test_added", "scan_added", "sla_breach", "sla_breach_combined", "risk_acceptance_expiration"]
+        fields = ["engagement_added", "close_engagement", "test_added", "scan_added", "sla_breach", "sla_breach_combined", "risk_acceptance_expiration", "risk_acceptance_request"]
 
 
 class AjaxChoiceField(forms.ChoiceField):

--- a/dojo/models.py
+++ b/dojo/models.py
@@ -3722,6 +3722,7 @@ class Risk_Acceptance(models.Model):
     expiration_date_handled = models.DateTimeField(default=None, null=True, blank=True, help_text=_("(readonly) When the risk acceptance expiration was handled (manually or by the daily job)."))
     reactivate_expired = models.BooleanField(null=False, blank=False, default=True, verbose_name=_("Reactivate findings on expiration"), help_text=_("Reactivate findings when risk acceptance expires?"))
     restart_sla_expired = models.BooleanField(default=False, null=False, verbose_name=_("Restart SLA on expiration"), help_text=_("When enabled, the SLA for findings is restarted when the risk acceptance expires."))
+    permanent = models.BooleanField(default=False, help_text=_("Indicates this risk acceptance does not expire."))
 
     notes = models.ManyToManyField(Notes, editable=False)
     created = models.DateTimeField(auto_now_add=True, null=False)
@@ -4118,6 +4119,9 @@ class Notifications(models.Model):
     risk_acceptance_expiration = MultiSelectField(choices=NOTIFICATION_CHOICES, default=DEFAULT_NOTIFICATION, blank=True,
         verbose_name=_("Risk Acceptance Expiration"),
         help_text=_("Get notified of (upcoming) Risk Acceptance expiries"))
+    risk_acceptance_request = MultiSelectField(choices=NOTIFICATION_CHOICES, default=DEFAULT_NOTIFICATION, blank=True,
+        verbose_name=_("Risk Acceptance Requests"),
+        help_text=_("Get notified when a Risk Acceptance requires approval"))
     sla_breach_combined = MultiSelectField(choices=NOTIFICATION_CHOICES, default=DEFAULT_NOTIFICATION, blank=True,
         verbose_name=_("SLA breach (combined)"),
         help_text=_("Get notified of (upcoming) SLA breaches (a message per project)"))
@@ -4162,6 +4166,7 @@ class Notifications(models.Model):
                 result.sla_breach = {*result.sla_breach, *notifications.sla_breach}
                 result.sla_breach_combined = {*result.sla_breach_combined, *notifications.sla_breach_combined}
                 result.risk_acceptance_expiration = {*result.risk_acceptance_expiration, *notifications.risk_acceptance_expiration}
+                result.risk_acceptance_request = {*result.risk_acceptance_request, *notifications.risk_acceptance_request}
         return result
 
 

--- a/dojo/templates/dojo/approve_risk_acceptance.html
+++ b/dojo/templates/dojo/approve_risk_acceptance.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% load display_tags %}
+{% block content %}
+<h3>Approve Risk Acceptance</h3>
+<form method="post" class="form-horizontal">
+    {% csrf_token %}
+    {% include 'dojo/form_fields.html' with form=form %}
+    <div class="form-group">
+        <div class="col-sm-offset-2 col-sm-10">
+            <input class="btn btn-primary" type="submit" value="Approve"/>
+        </div>
+    </div>
+</form>
+{% endblock %}
+

--- a/dojo/templates/notifications/slack/risk_acceptance_request.tpl
+++ b/dojo/templates/notifications/slack/risk_acceptance_request.tpl
@@ -1,0 +1,11 @@
+{% load i18n %}
+{% load display_tags %}
+{% blocktranslate trimmed with ra=risk_acceptance.name eng=engagement.name url=url|full_url %}
+Risk acceptance "{{ ra }}" for engagement "{{ eng }}" requires approval: {{ url }}
+{% endblocktranslate %}
+{% if system_settings.disclaimer_notifications and system_settings.disclaimer_notifications.strip %}
+
+    {% trans "Disclaimer" %}:
+    {{ system_settings.disclaimer_notifications }}
+{% endif %}
+


### PR DESCRIPTION
## Summary
- add `permanent` flag on `Risk_Acceptance`
- create new `ApproveRiskAcceptanceForm` and approval view
- notify "Risk‑Approvers" group on new requests via Slack
- allow approvers to set decision, record approver in `accepted_by`
- support new notification type `risk_acceptance_request`

## Testing
- `ruff check dojo/api_v2/serializers.py dojo/engagement/views.py dojo/forms.py dojo/models.py dojo/db_migrations/0238_risk_acceptance_permanent_and_notifications.py`
- `python manage.py test unittests.test_risk_acceptance.TestRiskAcceptance --keepdb` *(failed: ModuleNotFoundError: No module named 'celery')*

------
https://chatgpt.com/codex/tasks/task_e_6882c543d87883299d1925987abbd57a