### PR TITLE
Add initialization endpoints for MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,35 @@ Navigate to `http://localhost:8080` to see your new instance!
 
 * [Docker / Docker Compose](readme-docs/DOCKER.md)
 * [SaaS](https://www.defectdojo.com/) - Includes Support & Supports the Project
+## MCP Server
+
+DefectDojo ships with a small MCP server to allow Copilot agents to query data. Start it with:
+
+```bash
+uvicorn mcp_server:app --host 0.0.0.0 --port 8000
+```
+
+Available endpoints:
+- `/` simple health check.
+- `/initialize` used by Copilot to handshake with the MCP server.
+- `/findings` uses DefectDojo's filters. Example: `/findings?severity=High&active=True`.
+- `/findings/{severity}` list findings filtered by severity.
+- `/risk-accepted` list items that are risk accepted.
+- `/critical-sla` list SLA information for critical findings.
+
+### Using Copilot Agent in VS Code
+
+1. Install the **GitHub Copilot Chat** extension.
+2. Add a workspace setting `.vscode/settings.json`:
+   ```json
+   {
+       "github.copilot.agent.custom": {
+           "dojo": "http://localhost:8000"
+       }
+   }
+   ```
+3. Start the MCP server with `uvicorn mcp_server:app --host 0.0.0.0 --port 8000` and use `@dojo` in Copilot Chat to query findings.
+4. The Copilot agent will POST to `/initialize` when connecting. Ensure the endpoint is reachable.
 
 ## Community, Getting Involved, and Updates
 

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1,0 +1,102 @@
+import os
+
+import django
+from fastapi import FastAPI, HTTPException, Request
+from pydantic import BaseModel
+
+# setup django environment
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "dojo.settings.settings")
+django.setup()
+
+from dojo.filters import ApiFindingFilter  # noqa: E402
+from dojo.models import Finding  # noqa: E402
+
+app = FastAPI(title="DefectDojo MCP")
+
+
+class InitResponse(BaseModel):
+    name: str
+    description: str
+    version: str
+    endpoints: list[str]
+
+
+class FindingOut(BaseModel):
+    id: int
+    title: str
+    severity: str
+    url: str | None
+
+
+class SLAOut(BaseModel):
+    id: int
+    title: str
+    sla_expiration_date: str | None
+
+
+@app.get("/")
+def root():
+    """Health check endpoint for Copilot."""
+    return {"status": "ok"}
+
+
+@app.post("/initialize", response_model=InitResponse)
+def initialize():
+    """Return basic metadata so Copilot can connect."""
+    return InitResponse(
+        name="DefectDojo MCP",
+        description="Query findings from DefectDojo",
+        version="1.0",
+        endpoints=[
+            "/findings",
+            "/findings/{severity}",
+            "/risk-accepted",
+            "/critical-sla",
+        ],
+    )
+
+
+@app.get("/findings", response_model=list[FindingOut])
+def list_findings(request: Request):
+    params = dict(request.query_params)
+    f = ApiFindingFilter(params, queryset=Finding.objects.all())
+    if not f.is_valid():
+        raise HTTPException(status_code=400, detail=f.errors)
+    return [
+        FindingOut(id=fi.id, title=fi.title, severity=fi.severity, url=fi.file_path)
+        for fi in f.qs
+    ]
+
+
+@app.get("/findings/{severity}", response_model=list[FindingOut])
+def findings_by_severity(severity: str, request: Request):
+    params = dict(request.query_params)
+    params["severity"] = severity
+    f = ApiFindingFilter(params, queryset=Finding.objects.all())
+    if not f.is_valid():
+        raise HTTPException(status_code=400, detail=f.errors)
+    return [
+        FindingOut(id=fi.id, title=fi.title, severity=fi.severity, url=fi.file_path)
+        for fi in f.qs
+    ]
+
+
+@app.get("/risk-accepted", response_model=list[FindingOut])
+def list_risk_accepted():
+    qs = Finding.objects.filter(risk_accepted=True)
+    return [FindingOut(id=f.id, title=f.title, severity=f.severity, url=f.file_path) for f in qs]
+
+
+@app.get("/critical-sla", response_model=list[SLAOut])
+def critical_sla():
+    qs = Finding.objects.filter(severity="Critical")
+    return [
+        SLAOut(
+            id=f.id,
+            title=f.title,
+            sla_expiration_date=f.sla_expiration_date.isoformat()
+            if f.sla_expiration_date
+            else None,
+        )
+        for f in qs
+    ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -77,3 +77,5 @@ PyYAML==6.0.2
 pyopenssl==25.1.0
 parameterized==0.9.0
 watchdog==6.0.0 # only needed for development, but would require some docker refactoring if we want to exclude it for production images
+fastapi==0.116.1
+uvicorn==0.35.0


### PR DESCRIPTION
## Summary
- implement `/` health check and `/initialize` handshake for MCP server
- tidy up MCP code and list comprehension
- document endpoints and initialization in README

## Testing
- `python manage.py test unittests.test_adminsite.AdminSite.test_is_model_defined --settings=dojo.settings.unittests -v2` *(fails: OperationalError: no such function: NOW)*

------
https://chatgpt.com/codex/tasks/task_e_6883414426a88329a5fc078632c7bfce