### PR TITLE
Add initialization endpoints for MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,29 @@ Navigate to `http://localhost:8080` to see your new instance!
 
 * [Docker / Docker Compose](readme-docs/DOCKER.md)
 * [SaaS](https://www.defectdojo.com/) - Includes Support & Supports the Project
+## MCP Server
+
+DefectDojo ships with a small MCP server that communicates directly with the API. Start it with:
+
+```bash
+python dojo_mcp.py
+```
+
+The server exposes tools to query products, engagements and findings and to update finding status.
+
+### Using Copilot Agent in VS Code
+
+1. Install the **GitHub Copilot Chat** extension.
+2. Add a workspace setting `.vscode/settings.json`:
+   ```json
+   {
+       "github.copilot.agent.custom": {
+           "dojo": "http://localhost:8010/mcp"
+       }
+   }
+   ```
+3. Launch the MCP server with `python dojo_mcp.py`.
+4. Copilot sends a JSON-RPC `initialize` request to the MCP server when connecting. Ensure the service is running and reachable.
 
 ## Community, Getting Involved, and Updates
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,19 @@ services:
           source: ./docker/extra_settings
           target: /app/docker/extra_settings
         - "defectdojo_media:${DD_MEDIA_ROOT:-/app/media}"
+  mcp:
+    image: "defectdojo/defectdojo-django:${DJANGO_VERSION:-latest}"
+    depends_on:
+      uwsgi:
+        condition: service_started
+    command: ["python", "dojo_mcp.py"]
+    environment:
+      DEFECTDOJO_API_URL: "http://uwsgi:8081/api/v2"
+    ports:
+      - target: 8010
+        published: 8010
+        protocol: tcp
+        mode: host
   initializer:
     image: "defectdojo/defectdojo-django:${DJANGO_VERSION:-latest}"
     depends_on:

--- a/dojo_mcp.py
+++ b/dojo_mcp.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import httpx
+from mcp.server.fastmcp import FastMCP
+
+API_URL = os.environ.get("DEFECTDOJO_API_URL", "http://localhost:8080/api/v2")
+API_TOKEN = os.environ.get("DEFECTDOJO_API_TOKEN")
+
+# Configure FastMCP server to listen on all interfaces by default
+mcp = FastMCP(
+    "dojo",
+    host=os.environ.get("FASTMCP_HOST", "0.0.0.0"),  # noqa: S104
+    port=int(os.environ.get("FASTMCP_PORT", "8010")),
+)
+
+_log = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+_log.info("Starting Dojo MCP server, API_URL=%s", API_URL)
+
+_session = httpx.Client(headers={"Authorization": f"Token {API_TOKEN}"} if API_TOKEN else {}, timeout=30)
+
+
+def _api_get(path: str, params: dict[str, Any] | None = None) -> Any:
+    """Helper to GET objects from the DefectDojo API."""
+    url = f"{API_URL.rstrip('/')}/{path.lstrip('/')}"
+    response = _session.get(url, params=params)
+    response.raise_for_status()
+    data = response.json()
+    # many API endpoints are paginated
+    return data.get("results", data)
+
+
+@mcp.tool()
+def list_products() -> list[dict]:
+    """Return all products."""
+    return _api_get("products/")
+
+
+@mcp.tool()
+def list_engagements(product_id: int | None = None) -> list[dict]:
+    """Return engagements, optionally filtered by product."""
+    params = {"product": product_id} if product_id else None
+    return _api_get("engagements/", params)
+
+
+@mcp.tool()
+def list_findings(
+    severity: str | None = None,
+    product_id: int | None = None,
+    engagement_id: int | None = None,
+) -> list[dict]:
+    """List findings using DefectDojo filters."""
+    params: dict[str, Any] = {}
+    if severity:
+        params["severity"] = severity
+    if product_id:
+        params["test__engagement__product"] = product_id
+    if engagement_id:
+        params["test__engagement"] = engagement_id
+    return _api_get("findings/", params)
+
+
+@mcp.tool()
+def findings_outside_sla() -> list[dict]:
+    """Return findings that violate SLA."""
+    return _api_get("findings/", {"outside_of_sla": 1})
+
+
+@mcp.tool()
+def list_risk_accepted() -> list[dict]:
+    """Return risk-accepted findings."""
+    return _api_get("findings/", {"status": 5})
+
+
+@mcp.tool()
+def critical_sla() -> list[dict]:
+    """Return critical findings that violate SLA."""
+    return _api_get("findings/", {"severity": "Critical", "outside_of_sla": 1})
+
+
+@mcp.tool()
+def update_finding_status(finding_id: int, **fields: Any) -> dict:
+    """Update fields on a finding."""
+    url = f"{API_URL.rstrip('/')}/findings/{finding_id}/"
+    response = _session.patch(url, json=fields)
+    response.raise_for_status()
+    return response.json()
+
+
+@mcp.tool()
+def benchmark_results(product_id: int) -> list[dict]:
+    """Return benchmark requirements for a product."""
+    return _api_get(f"benchmarks/{product_id}/")
+
+
+if __name__ == "__main__":
+    mcp.run(transport="streamable-http")

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1,0 +1,118 @@
+import os
+
+import django
+from fastapi import FastAPI, HTTPException, Request
+from pydantic import BaseModel
+
+# setup django environment
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "dojo.settings.settings")
+django.setup()
+
+from dojo.filters import ApiFindingFilter  # noqa: E402
+from dojo.models import Finding  # noqa: E402
+
+app = FastAPI(title="DefectDojo MCP")
+
+
+class InitResponse(BaseModel):
+    name: str
+    description: str
+    version: str
+    endpoints: list[str]
+
+
+class FindingOut(BaseModel):
+    id: int
+    title: str
+    severity: str
+    url: str | None
+
+
+class SLAOut(BaseModel):
+    id: int
+    title: str
+    sla_expiration_date: str | None
+
+
+@app.get("/")
+def root():
+    """Health check endpoint for Copilot."""
+    return {"status": "ok"}
+
+
+@app.post("/", response_model=InitResponse)
+async def root_initialize(request: Request):
+    """Handle JSON-RPC initialize calls posted to root."""
+    try:
+        payload = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid JSON")
+    if payload.get("method") != "initialize":
+        raise HTTPException(status_code=400, detail="Unsupported method")
+    return _initialize_response()
+
+
+def _initialize_response() -> InitResponse:
+    return InitResponse(
+        name="DefectDojo MCP",
+        description="Query findings from DefectDojo",
+        version="1.0",
+        endpoints=[
+            "/findings",
+            "/findings/{severity}",
+            "/risk-accepted",
+            "/critical-sla",
+        ],
+    )
+
+
+@app.post("/initialize", response_model=InitResponse)
+def initialize():
+    """Return basic metadata so Copilot can connect."""
+    return _initialize_response()
+
+
+@app.get("/findings", response_model=list[FindingOut])
+def list_findings(request: Request):
+    params = dict(request.query_params)
+    f = ApiFindingFilter(params, queryset=Finding.objects.all())
+    if not f.is_valid():
+        raise HTTPException(status_code=400, detail=f.errors)
+    return [
+        FindingOut(id=fi.id, title=fi.title, severity=fi.severity, url=fi.file_path)
+        for fi in f.qs
+    ]
+
+
+@app.get("/findings/{severity}", response_model=list[FindingOut])
+def findings_by_severity(severity: str, request: Request):
+    params = dict(request.query_params)
+    params["severity"] = severity
+    f = ApiFindingFilter(params, queryset=Finding.objects.all())
+    if not f.is_valid():
+        raise HTTPException(status_code=400, detail=f.errors)
+    return [
+        FindingOut(id=fi.id, title=fi.title, severity=fi.severity, url=fi.file_path)
+        for fi in f.qs
+    ]
+
+
+@app.get("/risk-accepted", response_model=list[FindingOut])
+def list_risk_accepted():
+    qs = Finding.objects.filter(risk_accepted=True)
+    return [FindingOut(id=f.id, title=f.title, severity=f.severity, url=f.file_path) for f in qs]
+
+
+@app.get("/critical-sla", response_model=list[SLAOut])
+def critical_sla():
+    qs = Finding.objects.filter(severity="Critical")
+    return [
+        SLAOut(
+            id=f.id,
+            title=f.title,
+            sla_expiration_date=f.sla_expiration_date.isoformat()
+            if f.sla_expiration_date
+            else None,
+        )
+        for f in qs
+    ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -77,3 +77,7 @@ PyYAML==6.0.2
 pyopenssl==25.1.0
 parameterized==0.9.0
 watchdog==6.0.0 # only needed for development, but would require some docker refactoring if we want to exclude it for production images
+fastapi==0.116.1
+uvicorn==0.35.0
+mcp==1.12.2
+httpx==0.27.0


### PR DESCRIPTION
## Summary
- build new `dojo_mcp.py` MCP server that queries the DefectDojo API
- extend tools for products, engagements, findings and SLA queries
- expose the MCP service in docker-compose on port 8010
- document how to run the MCP server and use it with Copilot
- declare `httpx` dependency

## Testing
- `ruff check dojo_mcp.py mcp_server.py` *(passes)*
- `python manage.py test unittests.test_adminsite.AdminSite.test_is_model_defined --settings=dojo.settings.unittests -v2` *(fails: OperationalError: no such function: NOW)*

------
https://chatgpt.com/codex/tasks/task_e_6883414426a88329a5fc078632c7bfce