### PR TITLE
Clean up MCP service

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,31 @@ Navigate to `http://localhost:8080` to see your new instance!
 
 * [Docker / Docker Compose](readme-docs/DOCKER.md)
 * [SaaS](https://www.defectdojo.com/) - Includes Support & Supports the Project
+## MCP Server
+
+DefectDojo ships with a small MCP server that communicates directly with the API. Start it with:
+
+```bash
+python dojo_mcp.py
+```
+
+The server exposes tools to query products, engagements and findings and to update finding status. It is also
+included as the `mcp` service in `docker-compose.yml`, listening on port `8010`.
+Set `DEFECTDOJO_API_TOKEN` if authentication is required.
+
+### Using Copilot Agent in VS Code
+
+1. Install the **GitHub Copilot Chat** extension.
+2. Add a workspace setting `.vscode/settings.json`:
+   ```json
+   {
+       "github.copilot.agent.custom": {
+           "dojo": "http://localhost:8010/mcp"
+       }
+   }
+   ```
+3. Launch the MCP server with `python dojo_mcp.py`.
+4. Copilot sends a JSON-RPC `initialize` request to the MCP server when connecting. Ensure the service is running and reachable.
 
 ## Community, Getting Involved, and Updates
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,19 @@ services:
           source: ./docker/extra_settings
           target: /app/docker/extra_settings
         - "defectdojo_media:${DD_MEDIA_ROOT:-/app/media}"
+  mcp:
+    image: "defectdojo/defectdojo-django:${DJANGO_VERSION:-latest}"
+    depends_on:
+      uwsgi:
+        condition: service_started
+    entrypoint: ["python", "dojo_mcp.py"]
+    environment:
+      DEFECTDOJO_API_URL: "http://uwsgi:8081/api/v2"
+    ports:
+      - target: 8010
+        published: 8010
+        protocol: tcp
+        mode: host
   initializer:
     image: "defectdojo/defectdojo-django:${DJANGO_VERSION:-latest}"
     depends_on:

--- a/dojo_mcp.py
+++ b/dojo_mcp.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import httpx
+from mcp.server.fastmcp import FastMCP
+
+API_URL = os.environ.get("DEFECTDOJO_API_URL", "http://localhost:8080/api/v2")
+API_TOKEN = os.environ.get("DEFECTDOJO_API_TOKEN")
+
+# Configure FastMCP server to listen on all interfaces by default
+mcp = FastMCP(
+    "dojo",
+    host=os.environ.get("FASTMCP_HOST", "0.0.0.0"),  # noqa: S104
+    port=int(os.environ.get("FASTMCP_PORT", "8010")),
+)
+
+_log = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+_log.info("Starting Dojo MCP server, API_URL=%s", API_URL)
+
+_session = httpx.Client(headers={"Authorization": f"Token {API_TOKEN}"} if API_TOKEN else {}, timeout=30)
+
+
+def _api_get(path: str, params: dict[str, Any] | None = None) -> Any:
+    """Helper to GET objects from the DefectDojo API."""
+    url = f"{API_URL.rstrip('/')}/{path.lstrip('/')}"
+    response = _session.get(url, params=params)
+    response.raise_for_status()
+    data = response.json()
+    # many API endpoints are paginated
+    return data.get("results", data)
+
+
+@mcp.tool()
+def list_products() -> list[dict]:
+    """Return all products."""
+    return _api_get("products/")
+
+
+@mcp.tool()
+def list_engagements(product_id: int | None = None) -> list[dict]:
+    """Return engagements, optionally filtered by product."""
+    params = {"product": product_id} if product_id else None
+    return _api_get("engagements/", params)
+
+
+@mcp.tool()
+def list_findings(
+    severity: str | None = None,
+    product_id: int | None = None,
+    engagement_id: int | None = None,
+) -> list[dict]:
+    """List findings using DefectDojo filters."""
+    params: dict[str, Any] = {}
+    if severity:
+        params["severity"] = severity
+    if product_id:
+        params["test__engagement__product"] = product_id
+    if engagement_id:
+        params["test__engagement"] = engagement_id
+    return _api_get("findings/", params)
+
+
+@mcp.tool()
+def findings_outside_sla() -> list[dict]:
+    """Return findings that violate SLA."""
+    return _api_get("findings/", {"outside_of_sla": 1})
+
+
+@mcp.tool()
+def list_risk_accepted() -> list[dict]:
+    """Return risk-accepted findings."""
+    return _api_get("findings/", {"status": 5})
+
+
+@mcp.tool()
+def critical_sla() -> list[dict]:
+    """Return critical findings that violate SLA."""
+    return _api_get("findings/", {"severity": "Critical", "outside_of_sla": 1})
+
+
+@mcp.tool()
+def update_finding_status(finding_id: int, **fields: Any) -> dict:
+    """Update fields on a finding."""
+    url = f"{API_URL.rstrip('/')}/findings/{finding_id}/"
+    response = _session.patch(url, json=fields)
+    response.raise_for_status()
+    return response.json()
+
+
+@mcp.tool()
+def benchmark_results(product_id: int) -> list[dict]:
+    """Return benchmark requirements for a product."""
+    return _api_get(f"benchmarks/{product_id}/")
+
+
+if __name__ == "__main__":
+    mcp.run(transport="streamable-http")

--- a/requirements.txt
+++ b/requirements.txt
@@ -77,3 +77,5 @@ PyYAML==6.0.2
 pyopenssl==25.1.0
 parameterized==0.9.0
 watchdog==6.0.0 # only needed for development, but would require some docker refactoring if we want to exclude it for production images
+mcp==1.12.2
+httpx==0.27.0


### PR DESCRIPTION
## Summary
- remove unused `mcp_server.py`
- expose MCP service via entrypoint in docker-compose
- document token and service port in README
- drop FastAPI/uvicorn requirements

## Testing
- `ruff check dojo_mcp.py`
- `python manage.py test unittests.test_adminsite.AdminSite.test_is_model_defined --settings=dojo.settings.unittests -v2` *(fails: OperationalError no such function: NOW)*

------
https://chatgpt.com/codex/tasks/task_e_6883414426a88329a5fc078632c7bfce